### PR TITLE
Enable drag nodes

### DIFF
--- a/js/minimap.js
+++ b/js/minimap.js
@@ -357,31 +357,9 @@ const drawRadar = () => {
 }
 
 network.on('afterDrawing', () => {
-  const {
-    clientWidth,
-    clientHeight
-  } = network.body.container;
-  const width = Math.round(clientWidth / ratio);
-  const height = Math.round(clientHeight / ratio);
-  const minimapImage = document.getElementById('minimapImage');
-  const minimapWrapper = document.getElementById('minimapWrapper');
-  // Initial render
-  if (!minimapImage.hasAttribute('src') || minimapImage.src === '') {
-    if (!minimapWrapper.style.width || !minimapWrapper.style.height) {
-      drawMinimapWrapper();
-    }
+    drawMinimapWrapper();
     drawMinimapImage();
     drawRadar();
-  } else if (
-    minimapWrapper.style.width !== `${width}px` ||
-    minimapWrapper.style.height !== `${height}px`
-  ) {
-    minimapImage.removeAttribute('src');
-    drawMinimapWrapper();
-    network.fit();
-  } else {
-    drawRadar();
-  }
 })
 
 // Extra settings and cool effects :)

--- a/js/minimap.js
+++ b/js/minimap.js
@@ -296,7 +296,7 @@ const options = {
     },
   },
   interaction: {
-    dragNodes: false,
+    dragNodes: true,
   },
 };
 const network = new vis.Network(container, data, options);
@@ -389,14 +389,18 @@ network.on('resize', () => {
   network.fit();
 })
 network.on('dragStart', () => {
+  if (network.getSelectedNodes().length === 0) {
   const minimapWrapper = document.getElementById('minimapWrapper');
   minimapWrapper.classList.remove('minimapWrapperIdle');
   minimapWrapper.classList.add('minimapWrapperMove');
+  }
 })
 network.on('dragEnd', () => {
+if (network.getSelectedNodes().length === 0) {
   const minimapWrapper = document.getElementById('minimapWrapper');
   minimapWrapper.classList.remove('minimapWrapperMove');
   minimapWrapper.classList.add('minimapWrapperIdle')
+  }
 })
 network.on('zoom', () => {
   const minimapWrapper = document.getElementById('minimapWrapper');


### PR DESCRIPTION
Node dragging vs panning (canvas dragging) can be distinguished by checking if nodes are selected during drag events. This will stop the classes from being applied to the minimap when dragging nodes.