### PR TITLE
Add ability to zoom, GUI mods, and some optimisations

### DIFF
--- a/css/default.css
+++ b/css/default.css
@@ -4,26 +4,22 @@
 */
 .wrapper {
     display: flex;
-    width: 1024px;
-    height: 768px;
-}
-#mynetwork {
+    height: 400px;
+  }
+  
+  #mynetwork {
     flex: 1;
     border: 1px solid #ddd;
-}
-.minimapRadar {
+  }
+  
+  #minimapRadar {
+      position: absolute;
+      background-color: transparent;
+      border: 1px solid grey;
+      user-select: none;
+  }
+  
+  .minimapImage {
     position: absolute;
-    background-color: rgba(16, 84, 154, 0.26);
-    cursor: move;
-}
-.minimapImage {
-    position: absolute;
-}
-.minimapWrapperIdle {
-    opacity: 0.2;
-    transition: opacity 0.5s;
-}
-.minimapWrapperMove {
-    opacity: 0.95;
-    transition: opacity 0.5s;
-}
+      user-select: none;
+  }

--- a/index.html
+++ b/index.html
@@ -11,13 +11,11 @@
 <body>
     <div class="wrapper">
         <div id="mynetwork"></div>
-        <div id="minimapWrapper"
-            style="position: absolute; margin: 5px; border: 1px solid #ddd; overflow: hidden; background-color: #FFF; z-index: 9;"
-            class="minimapWrapperIdle">
-            <img id="minimapImage" class="minimapImage" />
-            <div id="minimapRadar" class="minimapRadar"></div>
+        <div id="minimapWrapper" style="position: absolute; margin: 5px; border: 2px solid black; overflow: hidden; background-color: #FFF; z-index: 9;">
+          <img id="minimapImage" class="minimapImage" />
+          <div id="minimapRadar" class="minimapRadar"></div>
         </div>
-    </div>
+      </div>      
 </body>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/vis/4.21.0/vis-network.min.js"></script>
 <script src="js/minimap.js"></script>

--- a/js/minimap.js
+++ b/js/minimap.js
@@ -1,3 +1,7 @@
+/* A MiniMap for vis-network
+Draws a small version of the network, if and only if the whole network is not visible (i.e. some nodes are outside the viewport).  The visible portion of the network is outlined in the minimap.  Users can steer around the network by dragging or zooming the outline.  The minimap is updated whenever the network is resized, panned or zoomed.
+*/
+
 const ratio = 5; // Ratio is difference between original VisJS Network and Minimap.
 const nodes = [
   {
@@ -271,158 +275,263 @@ const edges = [
 ];
 
 // Create network
-const container = document.getElementById('mynetwork');
+const container = document.getElementById("mynetwork");
 const data = {
-  nodes: nodes,
-  edges: edges
+  nodes: new vis.DataSet(nodes),
+  edges: new vis.DataSet(edges)
 };
 
 // Network options
 const options = {
   nodes: {
-    shape: 'dot',
+    shape: "dot",
     size: 30,
     font: {
       size: 32,
-      color: '#333'
+      color: "#333"
     },
     borderWidth: 1
   },
   edges: {
-    arrows: 'to',
+    arrows: "to",
     chosen: false,
     color: {
-      color: '#333',
-    },
+      color: "#333"
+    }
   },
   interaction: {
-    dragNodes: false,
-  },
+    dragNodes: false
+  }
 };
 const network = new vis.Network(container, data, options);
 
-// Draw minimap wrapper
-const drawMinimapWrapper = () => {
-  const {
-    clientWidth,
-    clientHeight
-  } = network.body.container;
-  const minimapWrapper = document.getElementById('minimapWrapper');
-  const width = Math.round(clientWidth / ratio);
-  const height = Math.round(clientHeight / ratio);
-
-  minimapWrapper.style.width = `${width}px`;
-  minimapWrapper.style.height = `${height}px`;
-}
-// Draw minimap Image
-const drawMinimapImage = () => {
-  const originalCanvas = document.getElementsByTagName('canvas')[0]
-  const minimapImage = document.getElementById('minimapImage')
-
-  const {
-    clientWidth,
-    clientHeight
-  } = network.body.container
-
-  const tempCanvas = document.createElement('canvas')
-  const tempContext = tempCanvas.getContext('2d')
-
-  const width = Math.round((tempCanvas.width = clientWidth / ratio))
-  const height = Math.round((tempCanvas.height = clientHeight / ratio))
-
-  if (tempContext) {
-    tempContext.drawImage(originalCanvas, 0, 0, width, height)
-    minimapImage.src = tempCanvas.toDataURL()
-    minimapImage.width = width
-    minimapImage.height = height
-  }
-}
-
-var targetScale;
-
-// Draw minimap Radar
-const drawRadar = () => {
-  const {
-    clientWidth,
-    clientHeight
-  } = network.body.container
-  const minimapRadar = document.getElementById('minimapRadar')
-  const scale = network.getScale()
-  const translate = network.getViewPosition()
-  minimapRadar.style.transform = `translate(${(translate.x / ratio) *
-        targetScale}px, ${(translate.y / ratio) * targetScale}px) scale(${targetScale / scale})`
-  minimapRadar.style.width = `${clientWidth / ratio}px`
-  minimapRadar.style.height = `${clientHeight / ratio}px`
-}
-
-network.on('afterDrawing', () => {
-  const {
-    clientWidth,
-    clientHeight
-  } = network.body.container;
-  const width = Math.round(clientWidth / ratio);
-  const height = Math.round(clientHeight / ratio);
-  const minimapImage = document.getElementById('minimapImage');
-  const minimapWrapper = document.getElementById('minimapWrapper');
-  // Initial render
-  if (!minimapImage.hasAttribute('src') || minimapImage.src === '') {
-    if (!minimapWrapper.style.width || !minimapWrapper.style.height) {
-      drawMinimapWrapper();
-    }
+function drawMinimap(ratio = 5) {
+  let fullNetPane,
+    fullNetwork,
+    initialScale,
+    initialPosition,
+    minimapWidth,
+    minimapHeight;
+  const minimapWrapper = document.getElementById("minimapWrapper"); // a div to contain the minimap
+  const minimapImage = document.getElementById("minimapImage"); // an img, child of minimapWrapper
+  const minimapRadar = document.getElementById("minimapRadar"); // a div, child of minimapWrapper
+  // size the minimap
+  minimapSetup();
+  // set up dragging of the radar overlay
+  let dragging = false; // if true, ignore clicks when user is dragging radar overlay
+  dragRadar();
+  /**
+   * Set the size of the minimap and its components
+   */
+  function minimapSetup() {
+    const { clientWidth, clientHeight } = network.body.container;
+    minimapWidth = clientWidth / ratio;
+    minimapHeight = clientHeight / ratio;
+    minimapWrapper.style.width = `${minimapWidth}px`;
+    minimapWrapper.style.height = `${minimapHeight}px`;
+    minimapRadar.style.width = `${minimapWidth}px`;
+    minimapRadar.style.height = `${minimapHeight}px`;
     drawMinimapImage();
     drawRadar();
-    targetScale = network.view.targetScale;
-  } else if (
-    minimapWrapper.style.width !== `${width}px` ||
-    minimapWrapper.style.height !== `${height}px`
-  ) {
-    minimapImage.removeAttribute('src');
-    drawMinimapWrapper();
-    network.fit();
-  } else {
+  }
+  /**
+   * Draw a copy of the full network offscreen, then create an image of it
+   * The visible network can't be used, because it may be scaled and panned, but the minimap image needs to
+   * show the full network
+   */
+  function drawMinimapImage() {
+    if (! document.getElementById("fullnetPane")) {
+      // if the full network does not exist, create it
+      fullNetPane = document.createElement("div");
+      fullNetPane.style.position = "absolute";
+      fullNetPane.style.top = "-9999px";
+      fullNetPane.style.left = "-9999px";
+      fullNetPane.style.width = `${mynetwork.offsetWidth}px`;
+      fullNetPane.style.height = `${mynetwork.offsetHeight}px`;
+      fullNetPane.id = "fullNetPane";
+      mynetwork.appendChild(fullNetPane);
+      fullNetwork = new vis.Network(fullNetPane, data, {
+        physics: { enabled: false }
+      });
+    }
+    fullNetwork.setOptions();
+    fullNetwork.fit();
+    initialScale = fullNetwork.getScale();
+    initialPosition = fullNetwork.getViewPosition();
+
+    const fullNetworklCanvas = fullNetPane.firstElementChild.firstElementChild;
+    fullNetwork.on("afterDrawing", () => {
+      // make the image as a reduced version of the fullNetwork
+      const tempCanvas = document.createElement("canvas");
+      const tempContext = tempCanvas.getContext("2d");
+      tempCanvas.width = minimapWidth;
+      tempCanvas.height = minimapHeight;
+      tempContext.drawImage(
+        fullNetworklCanvas,
+        0,
+        0,
+        minimapWidth,
+        minimapHeight
+      );
+      minimapImage.src = tempCanvas.toDataURL();
+      minimapImage.width = minimapWidth;
+      minimapImage.height = minimapHeight;
+    });
+  }
+  /**
+   * Move a radar overlay on the minimap to show the current view of the network
+   */
+  function drawRadar() {
+    const scale = initialScale / network.getScale();
+    // fade out the whole minimap if the network is all visible in the viewport
+    // (there is no value in having a minimap in this case)
+    if (scale >= 1 && networkInPane()) {
+      minimapWrapper.style.opacity = 0;
+      return;
+    } else minimapWrapper.style.opacity = 1;
+    const currentDOMPosition = network.canvasToDOM(network.getViewPosition());
+    const initialDOMPosition = network.canvasToDOM(initialPosition);
+
+    minimapRadar.style.left = `${Math.round(
+      ((currentDOMPosition.x - initialDOMPosition.x) * scale) / ratio +
+        (minimapWidth * (1 - scale)) / 2
+    )}px`;
+    minimapRadar.style.top = `${Math.round(
+      ((currentDOMPosition.y - initialDOMPosition.y) * scale) / ratio +
+        (minimapHeight * (1 - scale)) / 2
+    )}px`;
+    minimapRadar.style.width = `${minimapWidth * scale}px`;
+    minimapRadar.style.height = `${minimapHeight * scale}px`;
+  }
+  /**
+   *
+   * @returns {boolean} - true if the network is entirely within the viewport
+   */
+  function networkInPane() {
+    const netPaneTopLeft = network.DOMtoCanvas({ x: 0, y: 0 });
+    const netPaneBottomRight = network.DOMtoCanvas({
+      x: mynetwork.clientWidth,
+      y: mynetwork.clientHeight
+    });
+    for (const nodeId of data.nodes.getIds()) {
+      const boundingBox = network.getBoundingBox(nodeId);
+      if (boundingBox.left < netPaneTopLeft.x) return false;
+      if (boundingBox.right > netPaneBottomRight.x) return false;
+      if (boundingBox.top < netPaneTopLeft.y) return false;
+      if (boundingBox.bottom > netPaneBottomRight.y) return false;
+    }
+    return true;
+  }
+  /**
+   * Whenever the network is resized, the minimap needs to be resized and the radar overlay moved
+   */
+  network.on("resize", () => {
+    minimapSetup();
+  });
+  /**
+   * Whenever the network is changed, panned or zoomed, the radar overlay needs to be moved
+   */
+  network.on("afterDrawing", () => {
     drawRadar();
+  });
+  /**
+   * Set up dragging of the radar overlay
+   */
+  function dragRadar() {
+    let x, y, radarStart;
+    minimapRadar.addEventListener("pointerdown", dragMouseDown);
+    minimapWrapper.addEventListener(
+      "wheel",
+      (e) => {
+        e.preventDefault();
+        // reject all but vertical touch movements
+        if (Math.abs(e.deltaX) <= 1) zoomscroll(e);
+      },
+      { passive: false }
+    );
+
+    function dragMouseDown(e) {
+      e.preventDefault();
+      (x = e.clientX), (y = e.clientY);
+      radarStart = { x: minimapRadar.offsetLeft, y: minimapRadar.offsetTop };
+      minimapRadar.addEventListener("pointermove", drag);
+      minimapRadar.addEventListener("pointerup", dragMouseUp);
+    }
+
+    function drag(e) {
+      e.preventDefault();
+      dragging = true;
+      let dx = e.clientX - x;
+      let dy = e.clientY - y;
+      let left = radarStart.x + dx;
+      let top = radarStart.y + dy;
+      if (left < 0) left = 0;
+      if (left + minimapRadar.offsetWidth >= minimapWidth)
+        left = minimapWidth - minimapRadar.offsetWidth;
+      if (top < 0) top = 0;
+      if (top + minimapRadar.offsetHeight >= minimapHeight)
+        top = minimapHeight - minimapRadar.offsetHeight;
+      minimapRadar.style.left = `${Math.round(left)}px`;
+      minimapRadar.style.top = `${Math.round(top)}px`;
+      let initialDOMPosition = network.canvasToDOM(initialPosition);
+      const scale = initialScale / network.getScale();
+      const radarRect = minimapRadar.getBoundingClientRect();
+      const wrapperRect = minimapWrapper.getBoundingClientRect();
+      network.moveTo({
+        position: network.DOMtoCanvas({
+          x:
+            ((radarRect.left -
+              wrapperRect.left +
+              (radarRect.width - wrapperRect.width) / 2) *
+              ratio) /
+              scale +
+            initialDOMPosition.x,
+          y:
+            ((radarRect.top -
+              wrapperRect.top +
+              (radarRect.height - wrapperRect.height) / 2) *
+              ratio) /
+              scale +
+            initialDOMPosition.y
+        })
+      });
+    }
+
+    function dragMouseUp(e) {
+      e.preventDefault();
+      if (!dragging) return;
+      minimapRadar.removeEventListener("pointermove", drag);
+      minimapRadar.removeEventListener("pointerup", dragMouseUp);
+    }
   }
-})
-
-// Extra settings and cool effects :)
-
-function dimMinimap() {
-  const minimapWrapper = document.getElementById('minimapWrapper');
-  minimapWrapper.classList.remove('minimapWrapperMove');
-  minimapWrapper.classList.add('minimapWrapperIdle');
+}
+/**
+ * Zoom using a trackpad (with a mousewheel or two fingers)
+ * @param {Event} event
+ */
+var clicks = 0; // accumulate 'mousewheel' clicks sent while display is updating
+var ticking = false; // if true, we are waiting for an AnimationFrame */
+// see https://www.html5rocks.com/en/tutorials/speed/animations/
+function zoomscroll(event) {
+  clicks += event.deltaY;
+  requestZoom();
+}
+function requestZoom() {
+  if (!ticking) requestAnimationFrame(zoomUpdate);
+  ticking = true;
+}
+const MOUSEWHEELZOOMRATE = 0.01; // how many 'clicks' of the mouse wheel/finger track correspond to 1 zoom increment
+function zoomUpdate() {
+  zoomincr(-clicks * MOUSEWHEELZOOMRATE);
+  ticking = false;
+  clicks = 0;
+}
+function zoomincr(incr) {
+  let newScale = network.getScale();
+  newScale += incr;
+  if (newScale > 4) newScale = 4;
+  if (newScale <= 0.1) newScale = 0.1;
+  network.moveTo({ scale: newScale });
 }
 
-function undimMinimap() {
-  const minimapWrapper = document.getElementById('minimapWrapper');
-  minimapWrapper.classList.remove('minimapWrapperIdle');
-  minimapWrapper.classList.add('minimapWrapperMove');
-}
-
-network.on('resize', () => {
-  network.fit();
-})
-network.on('dragStart', () => {
-  undimMinimap();
-})
-network.on('dragEnd', () => {
-  dimMinimap();
-})
-network.on('zoom', () => {
-  undimMinimap();
-})
-
-// Minimap pan handler
-document.getElementById('minimapWrapper').onmousemove = function(e) {
-  if(event.buttons == 1) {
-    e.preventDefault()
-    undimMinimap();
-    var rect = document.getElementById('minimapWrapper').getBoundingClientRect();
-    var x = (e.clientX - rect.left - rect.width / 2) * ratio / targetScale;
-    var y = (e.clientY - rect.top - rect.height / 2) * ratio / targetScale;
-    network.moveTo({'position': {'x': x, 'y': y}});
-  }
-}
-
-document.getElementById('minimapWrapper').onmouseup = function(e) {
-  dimMinimap();
-}
+drawMinimap();


### PR DESCRIPTION
Enhanced version of the vis-network minimap with:
* minimap appears only if some nodes are not visible in the network viewport
* when portions of the network are not visible, the minimap shows the whole network, with the visible part outlined
*  the outline moves when the network is panned and zoomed, so that the outline always shows the visible portion of the network
* the user can pan and zoom the outline and the network moves correspondingly in the viewport